### PR TITLE
fix(m1-c1): corregir bloques de código markdown anidados

### DIFF
--- a/Modulo 1 – Fundamentos Dev y pensamiento/Clase 1 - Pensamiento computacional y ecosistema dev/Clase 1 - Pensamiento computacional y ecosistema dev.md
+++ b/Modulo 1 – Fundamentos Dev y pensamiento/Clase 1 - Pensamiento computacional y ecosistema dev/Clase 1 - Pensamiento computacional y ecosistema dev.md
@@ -789,7 +789,7 @@ Ahora, usa IA para crear una versión "production-ready" completa.
 
 **Prompt efectivo** (guárdalo en `prompts_usados.md`):
 
-```markdown
+````markdown
 # Prompts Usados
 
 ## Prompt 1: Versión Production-Ready
@@ -823,7 +823,7 @@ Crea una CLI de gestión de tareas en Python con las siguientes características
 ¿Qué generó la IA que no esperabas?
 ¿Hay algo que no entiendes?
 ¿Qué adoptarías para tu versión híbrida?
-```
+````
 
 ---
 
@@ -831,7 +831,7 @@ Crea una CLI de gestión de tareas en Python con las siguientes características
 
 Crea `COMPARACION.md` con este template:
 
-```markdown
+````markdown
 # Comparación: Manual vs IA vs Híbrido
 
 ## 1. Versión Manual (`tareas.py`)
@@ -886,7 +886,7 @@ Crea `COMPARACION.md` con este template:
 
 **Principal aprendizaje de esta clase**:
 - [Tu mayor insight sobre desarrollo manual vs IA-asistido]
-```
+````
 
 ---
 
@@ -894,7 +894,7 @@ Crea `COMPARACION.md` con este template:
 
 Ya iniciaste `prompts_usados.md` en el Paso 4. Ahora añade:
 
-```markdown
+````markdown
 ## Prompts que NO funcionaron bien
 
 ### Prompt malo #1:
@@ -925,7 +925,7 @@ Mejora este código [pegar código]
 2. **Contexto** es crítico (lenguaje, versión, frameworks)
 3. **Output claro**: especifica formato, estructura, qué incluir/excluir
 4. **Constraints** ayudan: "solo usa stdlib", "máximo 100 líneas", "sin dependencias"
-```
+````
 
 ---
 


### PR DESCRIPTION
## 🐛 Problema

En la Clase 1 del Módulo 1, había bloques de código markdown anidados que usaban triple backticks (```) cuando deberían usar cuádruple backticks (````) para el bloque exterior.

Esto rompía el renderizado del markdown en los siguientes pasos:
- **Paso 4**: Prompt efectivo para versión production-ready
- **Paso 5**: Template de documento de comparación  
- **Paso 6**: Historial de prompts

## ✅ Solución

Cambié todos los bloques exteriores a usar `````markdown` (4 backticks) en lugar de ````markdown` (3 backticks).

### Antes (incorrecto):
```markdown
# Contenido
```python
código
```
```

### Después (correcto):
````markdown
# Contenido
```python
código
```
````

## 📝 Archivos Modificados

- `Modulo 1/Clase 1 - Pensamiento computacional y ecosistema dev/Clase 1 - Pensamiento computacional y ecosistema dev.md`
  - Línea 792: Paso 4 (Prompt efectivo)
  - Línea 834: Paso 5 (Template COMPARACION.md)
  - Línea 897: Paso 6 (Historial de prompts)

## ✅ Tests

- ✅ Pre-push hook validado
- ✅ Tests pasados con coverage 87.70%
- ✅ Sin secretos detectados

---

**Tipo**: Fix de documentación
**Impacto**: Bajo (solo renderizado de markdown)