### PR TITLE
fix(mod3-clase6): ensure Pydantic validation runs before JWT auth

### DIFF
--- a/Modulo 3 – Calidad y Seguridad/Clase 6 – Defensa completa y CICD inteligente/api/api.py
+++ b/Modulo 3 – Calidad y Seguridad/Clase 6 – Defensa completa y CICD inteligente/api/api.py
@@ -37,12 +37,12 @@ class CrearTareaRequest(BaseModel):
     # prioridad: str = Field(default="media", pattern="^(alta|media|baja)$")
 
 
-@app.post("/tareas", status_code=201, dependencies=[Depends(verificar_jwt)])
-def crear_tarea(cuerpo: CrearTareaRequest):
+@app.post("/tareas", status_code=201)
+def crear_tarea(cuerpo: CrearTareaRequest, _: dict = Depends(verificar_jwt)):
     tarea = servicio.crear(cuerpo.nombre)
     return tarea.model_dump()
 
 
-@app.get("/tareas", dependencies=[Depends(verificar_jwt)])
-def listar_tareas():
+@app.get("/tareas")
+def listar_tareas(_: dict = Depends(verificar_jwt)):
     return [t.model_dump() for t in servicio.listar()]


### PR DESCRIPTION
## Summary

Fix failing test in Module 3 Clase 6 where validation error (422) was incorrectly returning 401.

**Test**: `test_crear_tarea_con_nombre_vacio_devuelve_422`

**Status**: ✅ 6/6 tests PASSED

---

## Problem

The test was expecting `422 Unprocessable Entity` when sending an empty name, but was receiving `401 Unauthorized` instead.

**Root cause**: FastAPI executes `dependencies=[Depends(verificar_jwt)]` **BEFORE** validating the request body with Pydantic.

**Execution order (before fix)**:
1. FastAPI runs `verificar_jwt` dependency
2. If JWT is invalid/expired → returns 401
3. Never reaches Pydantic validation ❌

---

## Solution

Move `verificar_jwt` from endpoint dependencies to function parameter, allowing Pydantic to validate first.

**Execution order (after fix)**:
1. FastAPI validates `CrearTareaRequest` with Pydantic
2. If validation fails (e.g., `nombre=""`) → returns 422 ✅
3. If validation passes → then verifies JWT
4. If JWT invalid → returns 401

### Code Changes

**Before**:
```python
@app.post("/tareas", status_code=201, dependencies=[Depends(verificar_jwt)])
def crear_tarea(cuerpo: CrearTareaRequest):
    ...

@app.get("/tareas", dependencies=[Depends(verificar_jwt)])
def listar_tareas():
    ...
```

**After**:
```python
@app.post("/tareas", status_code=201)
def crear_tarea(cuerpo: CrearTareaRequest, _: dict = Depends(verificar_jwt)):
    ...

@app.get("/tareas")
def listar_tareas(_: dict = Depends(verificar_jwt)):
    ...
```

---

## Test Results

```bash
pytest tests/ -v --cov=api

6 passed in 2.51s

Coverage:
- api.py: 92.86%
- seguridad_jwt.py: 96.00%
- servicio_tareas.py: 93.75%
- repositorio_memoria.py: 91.67%
```

**Specific test now passes**:
- ✅ `test_crear_tarea_con_nombre_vacio_devuelve_422 PASSED`

---

## Impact

- **Affected class**: Module 3 Clase 6 (Defensa completa y CI/CD inteligente)
- **Tests fixed**: 1/6 (the failing test)
- **Coverage maintained**: 92.86% for api.py (>80% requirement)
- **No breaking changes**: All other tests still pass
- **Better UX**: Validation errors are now reported before authentication errors

---

## Test Plan

- [x] Run specific failing test → PASSED
- [x] Run all tests in class → 6/6 PASSED
- [x] Verify coverage > 80% → api.py at 92.86%
- [x] Test validation error returns 422 → ✅
- [x] Test valid request still works → ✅
- [x] Test JWT auth still works → ✅

---

## Context

Detected during CI matrix expansion in JAR-225. This bug was **pre-existing** (not caused by CI changes).

**CI Run**: https://github.com/jarkillo/master-desarrollo-ia/actions/runs/18619028586/job/53087639496

---

## Resolves

Closes JAR-246