### PR TITLE
fix(game): Use gosu instead of su-exec for Debian compatibility

### DIFF
--- a/ai-dev-academy-game/backend/Dockerfile
+++ b/ai-dev-academy-game/backend/Dockerfile
@@ -26,10 +26,10 @@ FROM python:3.12-slim
 # Set working directory
 WORKDIR /app
 
-# Install runtime dependencies (including su-exec for secure user switching)
+# Install runtime dependencies (including gosu for secure user switching)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
-    su-exec \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy virtual environment from builder

--- a/ai-dev-academy-game/backend/docker-entrypoint.sh
+++ b/ai-dev-academy-game/backend/docker-entrypoint.sh
@@ -11,4 +11,4 @@ fi
 
 # Switch to appuser and execute the command passed to docker run
 echo "Starting application as appuser..."
-exec su-exec appuser "$@"
+exec gosu appuser "$@"


### PR DESCRIPTION
## Problem

Docker build failing on Easypanel with Debian-based image:

```
E: Unable to locate package su-exec
ERROR: process "/bin/sh -c apt-get update && apt-get install..." did not complete successfully: exit code: 100
```

## Root Cause

`su-exec` is **Alpine-specific** and not available in Debian package repositories.

Our base image `python:3.12-slim` is **Debian-based** (not Alpine).

## Solution

Replace `su-exec` with `gosu` (Debian/Ubuntu equivalent):

**1. Dockerfile line 32**:
```dockerfile
# ❌ Before
apt-get install -y su-exec

# ✅ After
apt-get install -y gosu
```

**2. docker-entrypoint.sh line 14**:
```bash
# ❌ Before
exec su-exec appuser "$@"

# ✅ After
exec gosu appuser "$@"
```

## Why `gosu`?

Both `su-exec` (Alpine) and `gosu` (Debian) do the same thing:
- Securely switch from root to non-root user
- Avoid `sudo` overhead
- Properly handle signals

`gosu` is the standard choice for Debian/Ubuntu-based Docker images.

## Testing

- ✅ Pre-commit hooks passed
- ⏳ CI will validate
- ⏳ Docker build should succeed on Easypanel

## Impact

Fixes Docker build blocker. After merge, Easypanel deployment will proceed past image build stage.

Related: JAR-270 (deployment to production)