### PR TITLE
fix(game): correct PlayerStats import in progress routes and tests

### DIFF
--- a/ai-dev-academy-game/backend/app/routes/progress.py
+++ b/ai-dev-academy-game/backend/app/routes/progress.py
@@ -8,7 +8,8 @@ from datetime import datetime
 
 from app.database import get_db
 from app.models.player import Player
-from app.models.progress import Progress, PlayerStats
+from app.models.progress import Progress
+from app.models.achievement import PlayerStats
 from app.schemas.progress import (
     ProgressCreate,
     ProgressUpdate,

--- a/ai-dev-academy-game/backend/tests/test_achievements.py
+++ b/ai-dev-academy-game/backend/tests/test_achievements.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import sessionmaker
 from app.main import app
 from app.database import Base, get_db
 from app.models.player import Player
-from app.models.progress import PlayerStats
+from app.models.achievement import PlayerStats
 
 
 # Test database setup

--- a/ai-dev-academy-game/backend/tests/test_progress.py
+++ b/ai-dev-academy-game/backend/tests/test_progress.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import sessionmaker
 from app.main import app
 from app.database import Base, get_db
 from app.models.player import Player
-from app.models.progress import PlayerStats
+from app.models.achievement import PlayerStats
 
 
 # Test database setup


### PR DESCRIPTION
## Summary

Fixed `ImportError` discovered during local Docker testing where `PlayerStats` was being imported from the wrong module.

## Changes

Fixed import statements in 3 files:

- **app/routes/progress.py**: Split combined import, now imports `PlayerStats` from `app.models.achievement`
- **tests/test_achievements.py**: Corrected import path
- **tests/test_progress.py**: Corrected import path

## Error Fixed

```
ImportError: cannot import name 'PlayerStats' from 'app.models.progress'
File "/app/app/routes/progress.py", line 11
```

## Root Cause

`PlayerStats` is defined in `app.models.achievement`, not `app.models.progress`. These files were importing from the wrong location.

## Testing

- ✅ Local grep confirms all `PlayerStats` imports now correct
- ⏳ Will test with local Docker Compose after merge

## Related

- Part of JAR-270 (VPS deployment preparation)
- Discovered during local Docker testing
- Similar to fix in PR #89 (player.py and minigames.py), but missed these files