### PR TITLE
fix(game): frontend health check using curl instead of wget

### DIFF
--- a/ai-dev-academy-game/frontend/Dockerfile
+++ b/ai-dev-academy-game/frontend/Dockerfile
@@ -39,9 +39,9 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # Expose port 80
 EXPOSE 80
 
-# Health check
+# Health check (using curl which is more reliable with IPv4/IPv6)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost/ || exit 1
+    CMD curl --fail --silent --show-error http://127.0.0.1/health || exit 1
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary

Fixed frontend container health check that was failing due to IPv6/IPv4 compatibility issues.

## Changes

**frontend/Dockerfile**:
- Changed health check from `wget` to `curl`
- Uses explicit IPv4 address `127.0.0.1` instead of `localhost`
- Checks `/health` endpoint instead of `/` for cleaner checks

## Root Cause

The previous health check was failing because:
- `wget` was attempting to connect to IPv6 `[::1]:80`
- nginx was only listening on IPv4
- This caused "Connection refused" errors

## Solution

Using `curl --fail --silent --show-error http://127.0.0.1/health`:
- ✅ Forces IPv4 connection
- ✅ More reliable than wget for Docker health checks
- ✅ Uses dedicated /health endpoint
- ✅ curl is available in nginx:alpine base image

## Testing

Before fix:
```
docker exec frontend wget --spider http://localhost/
→ Connection refused to [::1]:80
```

After fix:
```
docker exec frontend curl http://127.0.0.1/health
→ healthy
```

## Related

- Part of JAR-270 (VPS deployment)
- Discovered during local Docker testing
- Backend is already healthy, this completes the deployment stack