### PR TITLE
hotfix: Fix game crash on load (undefin unlockedAchievements)

### DIFF
--- a/ai-dev-academy-game/frontend/src/components/game/Dashboard.tsx
+++ b/ai-dev-academy-game/frontend/src/components/game/Dashboard.tsx
@@ -37,7 +37,7 @@ export const Dashboard = () => {
 
   const levelTitle = getLevelTitle(player.level);
   const xpProgress = getXPProgress(player.xp);
-  const recentAchievements = unlockedAchievements.slice(-3).reverse();
+  const recentAchievements = (unlockedAchievements || []).slice(-3).reverse();
 
   return (
     <div className="dashboard">
@@ -58,7 +58,7 @@ export const Dashboard = () => {
             Profile
           </button>
           <button onClick={() => setCurrentView('achievements')} className="btn-secondary">
-            Achievements ({unlockedAchievements.length})
+            Achievements ({(unlockedAchievements || []).length})
           </button>
         </div>
       </div>

--- a/ai-dev-academy-game/frontend/src/components/game/GameApp.tsx
+++ b/ai-dev-academy-game/frontend/src/components/game/GameApp.tsx
@@ -55,7 +55,7 @@ const AchievementsPlaceholder = () => {
         ← Back to Dashboard
       </button>
       <h2>All Achievements</h2>
-      <p>You have unlocked {unlockedAchievements.length} achievements!</p>
+      <p>You have unlocked {(unlockedAchievements || []).length} achievements!</p>
       <p>Full achievements gallery coming soon...</p>
     </div>
   );

--- a/ai-dev-academy-game/frontend/src/stores/gameStore.ts
+++ b/ai-dev-academy-game/frontend/src/stores/gameStore.ts
@@ -316,6 +316,11 @@ export const useGameStore = create<GameState>()(
         selectedModuleNumber: state.selectedModuleNumber,
         selectedClassNumber: state.selectedClassNumber,
       }),
+      merge: (persistedState, currentState) => ({
+        ...initialState,
+        ...currentState,
+        ...(persistedState as object),
+      }),
     }
   )
 );


### PR DESCRIPTION
## 🚨 Hotfix - Production Issue

### Problem
Game crashes on load with: `TypeError: Cannot read properties of undefined (reading 'slice')`

**Affected users**: Anyone loading the game dashboard after the latest deployment

### Root Cause
Zustand persist was not merging persisted localStorage state with `initialState`, causing non-persisted fields like `unlockedAchievements` to be `undefined` instead of their default value `[]`.

### Solution

**3 files changed**:

1. **Dashboard.tsx** (2 fixes):
   - Line 40: `(unlockedAchievements || []).slice(-3)` - prevent crash on slice()
   - Line 61: `(unlockedAchievements || []).length` - prevent crash on length access

2. **GameApp.tsx** (1 fix):
   - Line 58: `(unlockedAchievements || []).length` - prevent crash in Achievements view

3. **gameStore.ts** (structural fix):
   - Added `merge` function to persist config to always merge with `initialState`
   - Ensures all non-persisted fields have default values on hydration

### Testing
- [x] Code compiles without errors
- [x] Fallback guards added for all `unlockedAchievements` access
- [x] Persist merge function ensures future compatibility

### Deployment
This is a hotfix for production. After merge, redeploy immediately.

Fixes crash reported in production at https://curso.sintetikamusic.com